### PR TITLE
Internal/0/fix current account duplicate reply

### DIFF
--- a/android/src/main/kotlin/com/example/msal_auth/MsalAuth.kt
+++ b/android/src/main/kotlin/com/example/msal_auth/MsalAuth.kt
@@ -169,7 +169,10 @@ class MsalAuth(internal val context: Context) {
      */
     internal fun currentAccountCallback(result: MethodChannel.Result): CurrentAccountCallback {
         return object : CurrentAccountCallback {
+            private var isResultSubmitted = false
             override fun onAccountLoaded(activeAccount: IAccount?) {
+                if (isResultSubmitted) return
+                isResultSubmitted = true
                 if (activeAccount == null) {
                     setNoCurrentAccountException(result)
                     return
@@ -178,6 +181,8 @@ class MsalAuth(internal val context: Context) {
             }
 
             override fun onAccountChanged(priorAccount: IAccount?, currentAccount: IAccount?) {
+                if (isResultSubmitted) return
+                isResultSubmitted = true
                 if (currentAccount == null) {
                     setNoCurrentAccountException(result)
                     return
@@ -186,6 +191,8 @@ class MsalAuth(internal val context: Context) {
             }
 
             override fun onError(exception: MsalException) {
+                if (isResultSubmitted) return
+                isResultSubmitted = true
                 setMsalException(exception, result)
             }
         }


### PR DESCRIPTION
## Summary
  - Fix fatal `IllegalStateException: Reply already submitted` crash caused by MSAL's `CurrentAccountCallback` invoking both `onAccountLoaded` and `onAccountChanged` on the same callback instance, resulting in `MethodChannel.Result` being submitted twice

  ## Root Cause
  MSAL's `SingleAccountPublicClientApplication.getCurrentAccountAsync()` internally calls `checkCurrentAccountNotifyCallback`, which can trigger both `onAccountLoaded` and `onAccountChanged` on the same `CurrentAccountCallback`. Each method called `result.success()` or `result.error()`, but Flutter's `MethodChannel.Result` only allows a single reply — the second call caused a fatal native crash.

  ## Fix
  Added an `isResultSubmitted` guard flag to `currentAccountCallback` so only the first callback to fire submits the reply. Subsequent callbacks are silently ignored.