### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,4 +9,4 @@ jobs:
   publish:
     permissions:
       id-token: write
-    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
+    uses: dart-lang/setup-dart/.github/workflows/publish.yml@65eb853c7ba17dde3be364c3d2858773e7144260 # v1


### PR DESCRIPTION
Pin all GitHub Actions `uses:` references to immutable commit SHAs (with version tags kept as comments) to mitigate tag-mutation supply chain attacks. Closes #891 in HavenEngineering/product-exp-team.