### PR TITLE
Add clearPersistedAccount to resolve orphaned MSAL cache on Android

### DIFF
--- a/android/src/main/kotlin/com/example/msal_auth/MsalAuthHandler.kt
+++ b/android/src/main/kotlin/com/example/msal_auth/MsalAuthHandler.kt
@@ -304,13 +304,6 @@ class MsalAuthHandler(private val msal: MsalAuth) : MethodChannel.MethodCallHand
     }
 
     /**
-     * Set the error for public client app is not initialized.
-     * This is a custom exception created at Dart side.
-     *
-     * @param methodName the name of the method called.
-     * @param result the result of the method call.
-     */
-    /**
      * Clears MSAL's persisted single account from SharedPreferences.
      * Resolves the "current_account_mismatch" dead loop when the broker
      * no longer recognizes the stale cached account.
@@ -336,6 +329,13 @@ class MsalAuthHandler(private val msal: MsalAuth) : MethodChannel.MethodCallHand
         }
     }
 
+    /**
+     * Set the error for public client app is not initialized.
+     * This is a custom exception created at Dart side.
+     *
+     * @param methodName the name of the method called.
+     * @param result the result of the method call.
+     */
     private fun setPcaInitError(methodName: String, result: MethodChannel.Result) {
         result.error(
             "PCA_INIT",

--- a/android/src/main/kotlin/com/example/msal_auth/MsalAuthHandler.kt
+++ b/android/src/main/kotlin/com/example/msal_auth/MsalAuthHandler.kt
@@ -304,13 +304,17 @@ class MsalAuthHandler(private val msal: MsalAuth) : MethodChannel.MethodCallHand
     }
 
     /**
-     * Clears MSAL's persisted single account from SharedPreferences.
-     * Resolves the "current_account_mismatch" dead loop when the broker
-     * no longer recognizes the stale cached account.
+     * Removes only the current-account key from MSAL's SharedPreferences,
+     * leaving other persisted state (e.g. credential cache metadata) intact.
+     * Breaks the "current_account_mismatch" dead loop that occurs when the
+     * broker no longer recognizes the stale cached account.
      *
-     * The SharedPreferences name corresponds to
-     * [SingleAccountPublicClientApplication.SINGLE_ACCOUNT_CREDENTIAL_SHARED_PREFERENCES]
-     * which is a public constant in MSAL Android (verified in v6.0.1).
+     * Uses [SharedPreferences.Editor.commit] (synchronous) so the result
+     * reflects whether the write actually succeeded.
+     *
+     * References:
+     * - [SingleAccountPublicClientApplication.SINGLE_ACCOUNT_CREDENTIAL_SHARED_PREFERENCES]
+     * - [SingleAccountPublicClientApplication.CURRENT_ACCOUNT_SHARED_PREFERENCE_KEY]
      *
      * @see <a href="https://github.com/AzureAD/microsoft-authentication-library-for-android/blob/master/msal/src/main/java/com/microsoft/identity/client/SingleAccountPublicClientApplication.java">SingleAccountPublicClientApplication source</a>
      */
@@ -318,8 +322,19 @@ class MsalAuthHandler(private val msal: MsalAuth) : MethodChannel.MethodCallHand
         try {
             val prefsName = SingleAccountPublicClientApplication.SINGLE_ACCOUNT_CREDENTIAL_SHARED_PREFERENCES
             val prefs = msal.context.getSharedPreferences(prefsName, Context.MODE_PRIVATE)
-            prefs.edit().clear().apply()
-            result.success(true)
+            val cleared = prefs.edit()
+                .remove(SingleAccountPublicClientApplication.CURRENT_ACCOUNT_SHARED_PREFERENCE_KEY)
+                .commit()
+
+            if (cleared) {
+                result.success(true)
+            } else {
+                result.error(
+                    "CLEAR_ACCOUNT_ERROR",
+                    "Failed to persist account removal",
+                    null
+                )
+            }
         } catch (e: Exception) {
             result.error(
                 "CLEAR_ACCOUNT_ERROR",

--- a/android/src/main/kotlin/com/example/msal_auth/MsalAuthHandler.kt
+++ b/android/src/main/kotlin/com/example/msal_auth/MsalAuthHandler.kt
@@ -1,5 +1,6 @@
 package com.example.msal_auth
 
+import android.content.Context
 import com.google.gson.Gson
 import com.microsoft.identity.client.AcquireTokenParameters
 import com.microsoft.identity.client.AcquireTokenSilentParameters
@@ -77,6 +78,8 @@ class MsalAuthHandler(private val msal: MsalAuth) : MethodChannel.MethodCallHand
             "signOut" -> signOut(result)
 
             "isSharedDevice" -> isSharedDevice(result)
+
+            "clearPersistedAccount" -> clearPersistedAccount(result)
 
             "getAccount" -> {
                 val identifier = call.arguments as String
@@ -307,6 +310,32 @@ class MsalAuthHandler(private val msal: MsalAuth) : MethodChannel.MethodCallHand
      * @param methodName the name of the method called.
      * @param result the result of the method call.
      */
+    /**
+     * Clears MSAL's persisted single account from SharedPreferences.
+     * Resolves the "current_account_mismatch" dead loop when the broker
+     * no longer recognizes the stale cached account.
+     *
+     * The SharedPreferences name corresponds to
+     * [SingleAccountPublicClientApplication.SINGLE_ACCOUNT_CREDENTIAL_SHARED_PREFERENCES]
+     * which is a public constant in MSAL Android (verified in v6.0.1).
+     *
+     * @see <a href="https://github.com/AzureAD/microsoft-authentication-library-for-android/blob/master/msal/src/main/java/com/microsoft/identity/client/SingleAccountPublicClientApplication.java">SingleAccountPublicClientApplication source</a>
+     */
+    private fun clearPersistedAccount(result: MethodChannel.Result) {
+        try {
+            val prefsName = SingleAccountPublicClientApplication.SINGLE_ACCOUNT_CREDENTIAL_SHARED_PREFERENCES
+            val prefs = msal.context.getSharedPreferences(prefsName, Context.MODE_PRIVATE)
+            prefs.edit().clear().apply()
+            result.success(true)
+        } catch (e: Exception) {
+            result.error(
+                "CLEAR_ACCOUNT_ERROR",
+                "Failed to clear persisted account: ${e.localizedMessage}",
+                null
+            )
+        }
+    }
+
     private fun setPcaInitError(methodName: String, result: MethodChannel.Result) {
         result.error(
             "PCA_INIT",

--- a/android/src/main/kotlin/com/example/msal_auth/MsalAuthHandler.kt
+++ b/android/src/main/kotlin/com/example/msal_auth/MsalAuthHandler.kt
@@ -338,7 +338,7 @@ class MsalAuthHandler(private val msal: MsalAuth) : MethodChannel.MethodCallHand
         } catch (e: Exception) {
             result.error(
                 "CLEAR_ACCOUNT_ERROR",
-                "Failed to clear persisted account: ${e.localizedMessage}",
+                "Failed to clear persisted account: ${e.localizedMessage ?: e.toString()}",
                 null
             )
         }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   clock:
     dependency: transitive
     description:
@@ -71,26 +71,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.9"
+    version: "11.0.2"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.9"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
@@ -103,26 +103,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   msal_auth:
     dependency: "direct main"
     description:
@@ -187,18 +187,18 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.10"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   vm_service:
     dependency: transitive
     description:
@@ -208,5 +208,5 @@ packages:
     source: hosted
     version: "15.0.0"
 sdks:
-  dart: ">=3.7.0-0 <4.0.0"
+  dart: ">=3.9.0-0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/ios/Classes/MsalAuthPlugin.swift
+++ b/ios/Classes/MsalAuthPlugin.swift
@@ -95,6 +95,8 @@ public class MsalAuthPlugin: NSObject, FlutterPlugin {
 
         case "signOut": signOut(result: result)
 
+        case "clearPersistedAccount": result(true)
+
         case "getAccount":
             guard let identifier = call.arguments as? String else {
                 setInternalError(methodName: call.method, result: result)

--- a/lib/src/core/single_account_pca.dart
+++ b/lib/src/core/single_account_pca.dart
@@ -73,8 +73,8 @@ class SingleAccountPca extends PublicClientApplication {
   Future<bool> clearPersistedAccount() async {
     try {
       final result =
-          await kMethodChannel.invokeMethod('clearPersistedAccount');
-      return result ?? true;
+          await kMethodChannel.invokeMethod<bool>('clearPersistedAccount');
+      return result ?? false;
     } on PlatformException catch (e) {
       throw e.convertToMsalException();
     }

--- a/lib/src/core/single_account_pca.dart
+++ b/lib/src/core/single_account_pca.dart
@@ -60,4 +60,23 @@ class SingleAccountPca extends PublicClientApplication {
       throw e.convertToMsalException();
     }
   }
+
+  /// Clears the persisted account from MSAL's local cache (Android only).
+  ///
+  /// Use this when the device enters a state where [signOut] fails because
+  /// the broker no longer recognizes the cached account, and [acquireToken]
+  /// throws a "current_account_mismatch" error. Calling this method removes
+  /// the stale account entry from SharedPreferences, allowing a fresh
+  /// interactive login.
+  ///
+  /// On iOS this is a no-op since the equivalent state does not occur.
+  Future<bool> clearPersistedAccount() async {
+    try {
+      final result =
+          await kMethodChannel.invokeMethod('clearPersistedAccount');
+      return result ?? true;
+    } on PlatformException catch (e) {
+      throw e.convertToMsalException();
+    }
+  }
 }

--- a/lib/src/core/single_account_pca.dart
+++ b/lib/src/core/single_account_pca.dart
@@ -69,7 +69,7 @@ class SingleAccountPca extends PublicClientApplication {
   /// the stale account entry from SharedPreferences, allowing a fresh
   /// interactive login.
   ///
-  /// On iOS this is a no-op since the equivalent state does not occur.
+  /// On iOS and macOS this is a no-op since the equivalent state does not occur.
   Future<bool> clearPersistedAccount() async {
     try {
       final result =

--- a/macos/Classes/MsalAuthPlugin.swift
+++ b/macos/Classes/MsalAuthPlugin.swift
@@ -86,6 +86,8 @@ public class MsalAuthPlugin: NSObject, FlutterPlugin {
 
         case "signOut": signOut(result: result)
 
+        case "clearPersistedAccount": result(true)
+
         case "getAccount":
             guard let identifier = call.arguments as? String else {
                 setInternalError(methodName: call.method, result: result)

--- a/test/msal_auth_test.dart
+++ b/test/msal_auth_test.dart
@@ -1,1 +1,112 @@
-void main() {}
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:msal_auth/msal_auth.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late List<MethodCall> log;
+  late dynamic Function(MethodCall) handler;
+
+  setUp(() {
+    log = [];
+    handler = (_) => null;
+
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(kMethodChannel, (call) async {
+      log.add(call);
+      return handler(call);
+    });
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(kMethodChannel, null);
+  });
+
+  Future<SingleAccountPca> createPca() async {
+    handler = (call) {
+      switch (call.method) {
+        case 'createSingleAccountPca':
+          return true;
+        case 'clearPersistedAccount':
+          return true;
+        case 'signOut':
+          return true;
+        case 'currentAccount':
+          return <String, dynamic>{
+            'id': 'test-id',
+            'username': 'user@example.com',
+            'name': 'Test User',
+          };
+        default:
+          return null;
+      }
+    };
+
+    return SingleAccountPca.create(
+      clientId: 'test-client-id',
+      appleConfig:
+          AppleConfig(authority: 'https://login.microsoftonline.com/common'),
+    );
+  }
+
+  test(
+      'Given a persisted account exists, '
+      'When clearPersistedAccount is called, '
+      'Then it invokes the method channel and returns true', () async {
+    final pca = await createPca();
+
+    final result = await pca.clearPersistedAccount();
+
+    expect(result, true);
+    expect(log.any((c) => c.method == 'clearPersistedAccount'), true);
+  });
+
+  test(
+      'Given the native side throws, '
+      'When clearPersistedAccount is called, '
+      'Then it throws MsalException', () async {
+    final pca = await createPca();
+
+    handler = (call) {
+      if (call.method == 'clearPersistedAccount') {
+        throw PlatformException(
+          code: 'CLEAR_ACCOUNT_ERROR',
+          message: 'Failed to clear persisted account: test error',
+        );
+      }
+      return true;
+    };
+
+    expect(
+      pca.clearPersistedAccount,
+      throwsA(isA<MsalException>()),
+    );
+  });
+
+  test(
+      'Given a signed-in account, '
+      'When signOut is called, '
+      'Then it invokes the method channel and returns true', () async {
+    final pca = await createPca();
+
+    final result = await pca.signOut();
+
+    expect(result, true);
+    expect(log.any((c) => c.method == 'signOut'), true);
+  });
+
+  test(
+      'Given a cached account, '
+      'When currentAccount is accessed, '
+      'Then it returns the deserialized Account', () async {
+    final pca = await createPca();
+
+    final account = await pca.currentAccount;
+
+    expect(account.id, 'test-id');
+    expect(account.username, 'user@example.com');
+    expect(log.any((c) => c.method == 'currentAccount'), true);
+  });
+}

--- a/test/msal_auth_test.dart
+++ b/test/msal_auth_test.dart
@@ -64,6 +64,24 @@ void main() {
   });
 
   test(
+      'Given the native side returns null, '
+      'When clearPersistedAccount is called, '
+      'Then it returns false', () async {
+    final pca = await createPca();
+
+    handler = (call) {
+      if (call.method == 'clearPersistedAccount') {
+        return null;
+      }
+      return true;
+    };
+
+    final result = await pca.clearPersistedAccount();
+
+    expect(result, false);
+  });
+
+  test(
       'Given the native side throws, '
       'When clearPersistedAccount is called, '
       'Then it throws MsalException', () async {

--- a/test/msal_auth_test.dart
+++ b/test/msal_auth_test.dart
@@ -79,8 +79,8 @@ void main() {
       return true;
     };
 
-    expect(
-      pca.clearPersistedAccount,
+    await expectLater(
+      pca.clearPersistedAccount(),
       throwsA(isA<MsalException>()),
     );
   });


### PR DESCRIPTION
When the broker changes accounts and signOut fails, MSAL's SharedPreferences retains a stale account causing
current_account_mismatch on subsequent login attempts. This method clears the persisted single-account cache, breaking the dead loop. No-op on iOS.